### PR TITLE
Set y axis minimum to zero

### DIFF
--- a/page/index.html
+++ b/page/index.html
@@ -113,7 +113,8 @@
               },
               grid: {
                 color: Chart.defaults.borderColor
-              }
+              },
+              min: 0
             }
           },
           plugins: {


### PR DESCRIPTION
The y axis is currently set based on the minimum value of the dataset which skews the perception a little. Since we are counting failures (and zero is the target value) it makes more sense to have the y axis start at zero.

Unfortunately I couldn't test this PR since I don't have any data to show, but since the change is simple enough I was hoping you might be able to take a look at this.